### PR TITLE
Use TimeLib.h instead of Time.h

### DIFF
--- a/DCF77.cpp
+++ b/DCF77.cpp
@@ -22,7 +22,7 @@
 */
 
 #include <DCF77.h>       //https://github.com/thijse/Arduino-Libraries/downloads
-#include <Time.h>        //http://playground.arduino.cc/code/time
+#include <TimeLib.h>        //http://playground.arduino.cc/code/time
 #include <Utils.h>
 
 #define _DCF77_VERSION 1_0_0 // software version of this library

--- a/DCF77.h
+++ b/DCF77.h
@@ -6,7 +6,7 @@
 #else
 #include <WProgram.h> 
 #endif
-#include <Time.h>
+#include <TimeLib.h>
 
 #define MIN_TIME 1334102400     // Date: 11-4-2012
 #define MAX_TIME 4102444800     // Date:  1-1-2100

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ can be found here:
 ](http://thijs.elenbaas.net/2012/04/arduino-dcf77-radio-clock-receiver-library/)
     
     #include "DCF77.h"
-    #include "Time.h"
+    #include "TimeLib.h"
     
     #define DCF_PIN 2// Connection pin to DCF 77 device
     #define DCF_INTERRUPT 0  // Interrupt number associated with pin

--- a/examples/DCFBinaryStream/DCFBinaryStream.pde
+++ b/examples/DCFBinaryStream/DCFBinaryStream.pde
@@ -23,7 +23,7 @@
 
 
 #include <DCF77.h>       //https://github.com/thijse/Arduino-Libraries/downloads
-#include <Time.h>        //http://www.arduino.cc/playground/Code/Time
+#include <TimeLib.h>        //http://www.arduino.cc/playground/Code/Time
 
 #define DCF_PIN 2	         // Connection pin to DCF 77 device
 #define DCF_INTERRUPT 0		 // Interrupt number associated with pin

--- a/examples/InternalClockSync/InternalClockSync.pde
+++ b/examples/InternalClockSync/InternalClockSync.pde
@@ -20,7 +20,7 @@
  */
 
 #include "DCF77.h"
-#include "Time.h"
+#include "TimeLib.h"
 
 #define DCF_PIN 2	         // Connection pin to DCF 77 device
 #define DCF_INTERRUPT 0		 // Interrupt number associated with pin

--- a/examples/SyncProvider/SyncProvider.pde
+++ b/examples/SyncProvider/SyncProvider.pde
@@ -20,7 +20,7 @@
  */
 
 #include <DCF77.h>       //https://github.com/thijse/Arduino-Libraries/downloads
-#include <Time.h>        //http://www.arduino.cc/playground/Code/Time
+#include <TimeLib.h>        //http://www.arduino.cc/playground/Code/Time
 
 #define DCF_PIN 2	         // Connection pin to DCF 77 device
 #define DCF_INTERRUPT 0		 // Interrupt number associated with pin

--- a/examples/TimeZones/TimeZones.pde
+++ b/examples/TimeZones/TimeZones.pde
@@ -23,7 +23,7 @@
  */
 
 #include <DCF77.h>       //https://github.com/thijse/Arduino-Libraries/downloads
-#include <Time.h>        //http://www.arduino.cc/playground/Code/Time
+#include <TimeLib.h>        //http://www.arduino.cc/playground/Code/Time
 #include <Timezone.h>    //https://github.com/JChristensen/Timezone
 
 #define DCF_PIN 2	         // Connection pin to DCF 77 device

--- a/extras/documentation/html/_d_c_f77_8h_source.html
+++ b/extras/documentation/html/_d_c_f77_8h_source.html
@@ -62,7 +62,7 @@
 <a name="l00006"></a>00006 <span class="preprocessor">#else</span>
 <a name="l00007"></a>00007 <span class="preprocessor"></span><span class="preprocessor">#include &lt;WProgram.h&gt;</span> 
 <a name="l00008"></a>00008 <span class="preprocessor">#endif</span>
-<a name="l00009"></a>00009 <span class="preprocessor"></span><span class="preprocessor">#include &lt;Time.h&gt;</span>
+<a name="l00009"></a>00009 <span class="preprocessor"></span><span class="preprocessor">#include &lt;TimeLib.h&gt;</span>
 <a name="l00010"></a>00010 
 <a name="l00011"></a>00011 <span class="preprocessor">#define MIN_TIME 1334102400     // Date: 11-4-2012</span>
 <a name="l00012"></a>00012 <span class="preprocessor"></span><span class="preprocessor">#define MAX_TIME 4102444800     // Date:  1-1-2100</span>

--- a/utility/Utils.h
+++ b/utility/Utils.h
@@ -6,7 +6,7 @@
 #else
 #include <WProgram.h> 
 #endif
-#include <Time.h>
+#include <TimeLib.h>
 
 #define intDisable()      ({ uint8_t sreg = SREG; cli(); sreg; })
 #define intRestore(sreg)  SREG = sreg 


### PR DESCRIPTION
The new version of avr-libc included with Arduino IDE 1.6.10/Arduino AVR
Boards 1.6.12 has a file named time.h. This causes that file to be
included instead of the intended file on case insensitive operating
systems, resulting in compile failure. This is also an issue with
non-AVR boards. Recent versions of the Time library have a file named
TimeLib.h to solve this issue.
